### PR TITLE
change base debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:10
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Should be built based on Debian:10 (not :stable or :stable-slim) because the current stable version of Debian is 12. However, cr2hdr cannot be built on Debian 12