### PR TITLE
change debian version and ML source code URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     dcraw \
     make && \
     pip3 install docutils
-RUN hg clone -r unified https://bitbucket.org/hudson/magic-lantern
+RUN hg clone -r unified https://foss.heptapod.net/magic-lantern/magic-lantern
 WORKDIR /magic-lantern/modules/dual_iso/
 RUN make cr2hdr
 RUN cp /magic-lantern/modules/dual_iso/cr2hdr /usr/bin/cr2hdr

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:10
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Should be built based on Debian:10 (not :stable or :stable-slim) because the current stable version of Debian is 12. However, cr2hdr cannot be built on Debian 12.

update the new source code URL.